### PR TITLE
Support default values for mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ You can use it with [postcss-nested] plugin:
 }
 ```
 
+You can define default values for variables:
+```css
+@define-mixin icon $name, $padding: 16px {
+    padding-left: $(padding);
+    &::after {
+        position: absolute;
+        top: 0;
+        left: 0;
+        content: "";
+        background-url: url(/icons/$(name).png);
+    }
+}
+
+.search {
+    @mixin icon search;
+}
+```
+
 You can pass a block to mixin:
 
 ```css

--- a/test/test.js
+++ b/test/test.js
@@ -106,4 +106,24 @@ describe('postcss-mixins', function () {
              '@media {\n    a {}\n}');
     });
 
+
+    it('supports default values for variables in CSS mixins', function () {
+        test('@define-mixin color $color: black { color: $color $other; } ' +
+             'a { @mixin color; }',
+             'a { color: black $other; }');
+    });
+
+    it('supports variables with and without default values in CSS mixins', function () {
+        test('@define-mixin color $color1 $color2: red { color: $color1 $color2; } ' +
+             'a { @mixin color black; }',
+             'a { color: black red; }');
+    });
+
+    it('supports multiple variables with default values for in CSS mixins that are comma separated', function () {
+        test('@define-mixin color $color1: black, $color2: red { color: $color1 $color2; } ' +
+             'a { @mixin color; }',
+             'a { color: black red; }');
+    });
+
+
 });


### PR DESCRIPTION
Resolves and fills the need for #10.

Added test coverage for this feature. All tests Pass!

To install this branch, you can use `jspm install github:MadLittleMods/postcss-mixins@default-value-mixins`

### Syntax

`$foo: value`
`$foo: value $bar: value`
`$foo:value $bar:value`
`$foo:value,$bar:value`
`$foo: value, $bar: value`

### Example:

```css
@define-mixin icon $name, $padding: 16px {
    padding-left: $(padding);
    &::after {
        position: absolute;
        top: 0;
        left: 0;
        content: "";
        background-url: url(/icons/$(name).png);
    }
}

.search {
    @mixin icon search;
}
```