### PR TITLE
Rename @define-mixin to @mixin and @mixin to @include

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Note, that you must set this plugin before [postcss-simple-vars]
 and [postcss-nested].
 
 ```css
-@define-mixin icon $network, $color: blue {
+@mixin icon $network, $color: blue {
     .icon.is-$(network) {
         color: $color;
-        @mixin-content;
+        @content;
     }
     .icon.is-$(network):hover {
         color: white;
@@ -21,10 +21,10 @@ and [postcss-nested].
     }
 }
 
-@mixin icon twitter {
+@include icon twitter {
     background: url(twt.png);
 }
-@mixin icon youtube, red {
+@include icon youtube, red {
     background: url(youtube.png);
 }
 ```
@@ -76,7 +76,7 @@ See [postcss-simple-vars] docs for arguments syntax.
 You can use it with [postcss-nested] plugin:
 
 ```css
-@define-mixin icon $name {
+@mixin icon $name {
     padding-left: 16px;
     &::after {
         content: "";
@@ -85,7 +85,7 @@ You can use it with [postcss-nested] plugin:
 }
 
 .search {
-    @mixin icon search;
+    @include icon search;
 }
 ```
 
@@ -106,7 +106,7 @@ Also you should use function mixin if you need to change property names
 in mixin, because [postcss-simple-vars] doesn’t support variables
 in properties yet.
 
-First argument will be `@mixin` node, that called this mixin.
+First argument will be `@include` node, that called this mixin.
 You can insert your declarations or rule before or after this node.
 Other arguments will be taken from at-rule parameters.
 
@@ -131,7 +131,7 @@ require('postcss-mixins')({
 ```
 
 ```css
-@mixin icons signin;
+@include icons signin;
 ```
 
 ```css

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ var insertMixin = function (result, mixins, rule, opts) {
             throw rule.error('Undefined mixin ' + name);
         }
 
-    } else if ( mixin.name === 'define-mixin' ) {
+    } else if ( mixin.name === 'mixin' ) {
         var values = { };
         for ( var i = 0; i < meta.args.length; i++ ) {
             values[ meta.args[i][0] ] = params[i] || meta.args[i][1];
@@ -76,7 +76,7 @@ var insertMixin = function (result, mixins, rule, opts) {
             vars({ only: values })(proxy);
         }
         if ( meta.content ) {
-            proxy.eachAtRule('mixin-content', function (place) {
+            proxy.eachAtRule('content', function (place) {
                 place.replaceWith(rule.nodes);
             });
         }
@@ -123,7 +123,7 @@ var defineMixin = function (result, mixins, rule) {
     }
 
     var content = false;
-    rule.eachAtRule('mixin-content', function () {
+    rule.eachAtRule('content', function () {
         content = true;
         return false;
     });
@@ -162,9 +162,9 @@ module.exports = postcss.plugin('postcss-mixins', function (opts) {
     return function (css, result) {
         css.eachAtRule(function (rule) {
 
-            if ( rule.name === 'mixin' ) {
+            if ( rule.name === 'include' ) {
                 insertMixin(result, mixins, rule, opts);
-            } else if ( rule.name === 'define-mixin' ) {
+            } else if ( rule.name === 'mixin' ) {
                 defineMixin(result, mixins, rule);
             }
 

--- a/test/test.js
+++ b/test/test.js
@@ -14,16 +14,16 @@ describe('postcss-mixins', function () {
 
     it('throws error on unknown mixin', function () {
         expect(function () {
-            test('@mixin A');
+            test('@include A');
         }).to.throw('Undefined mixin A');
     });
 
     it('cans remove unknown mixin on request', function () {
-        test('@mixin A; a{}', 'a{}', { silent: true });
+        test('@include A; a{}', 'a{}', { silent: true });
     });
 
     it('supports functions mixins', function () {
-        test('a { @mixin color black; }', 'a { color: black; }', {
+        test('a { @include color black; }', 'a { color: black; }', {
             mixins: {
                 color: function (rule, color) {
                     rule.replaceWith({ prop: 'color', value: color });
@@ -33,7 +33,7 @@ describe('postcss-mixins', function () {
     });
 
     it('removes mixin at-rule', function () {
-        test('a { @mixin none; }', 'a { }', {
+        test('a { @include none; }', 'a { }', {
             mixins: {
                 none: function () { }
             }
@@ -41,7 +41,7 @@ describe('postcss-mixins', function () {
     });
 
     it('converts object from function to nodes', function () {
-        test('a { @mixin color black; }', 'a { color: black; }', {
+        test('a { @include color black; }', 'a { color: black; }', {
             mixins: {
                 color: function (rule, color) {
                     return { color: color };
@@ -51,7 +51,7 @@ describe('postcss-mixins', function () {
     });
 
     it('supports object mixins', function () {
-        test('@mixin obj;',
+        test('@include obj;',
              '@media screen {\n    b {\n        one: 1\n    }\n}', {
             mixins: {
                 obj: {
@@ -66,39 +66,39 @@ describe('postcss-mixins', function () {
     });
 
     it('supports CSS mixins', function () {
-        test('@define-mixin black { color: black; } a { @mixin black; }',
+        test('@mixin black { color: black; } a { @include black; }',
              'a { color: black; }');
     });
 
     it('uses variable', function () {
-        test('@define-mixin color $color { color: $color $other; } ' +
-             'a { @mixin color black; }',
+        test('@mixin color $color { color: $color $other; } ' +
+             'a { @include color black; }',
              'a { color: black $other; }');
     });
 
     it('supports default value', function () {
-        test('@define-mixin c $color: black { color: $color; } a { @mixin c; }',
+        test('@mixin c $color: black { color: $color; } a { @include c; }',
              'a { color: black; }');
     });
 
     it('supports mixins with content', function () {
-        test('@define-mixin m { @media { @mixin-content; } } @mixin m { a {} }',
+        test('@mixin m { @media { @content; } } @include m { a {} }',
              '@media {\n    a {}\n}');
     });
 
     it('uses variables', function () {
-        test('@define-mixin m $a, $b: b, $c: c { v: $a $b $c; } @mixin m 1, 2;',
+        test('@mixin m $a, $b: b, $c: c { v: $a $b $c; } @include m 1, 2;',
              'v: 1 2 c;');
     });
 
     it('loads mixins from dir', function () {
-        test('a { @mixin a 1; @mixin b; }', 'a { a: 1; b: 2; }', {
+        test('a { @include a 1; @include b; }', 'a { a: 1; b: 2; }', {
             mixinsDir: path.join(__dirname, 'mixins')
         });
     });
 
     it('loads mixins from dirs', function () {
-        test('a { @mixin a 1; @mixin c; }', 'a { a: 1; c: 3; }', {
+        test('a { @include a 1; @include c; }', 'a { a: 1; c: 3; }', {
             mixinsDir: [
                 path.join(__dirname, 'mixins'),
                 path.join(__dirname, 'other')
@@ -114,13 +114,13 @@ describe('postcss-mixins', function () {
                 }
             }
         }));
-        var result = proccessor.process('a{ @mixin empty; }');
+        var result = proccessor.process('a{ @include empty; }');
         expect(result.root.first.first.value).to.be.a('string');
     });
 
     it('supports deprecated variables syntax', function () {
         var result = postcss(mixins).process(
-            '@define-mixin m $a $b $c { v: $a $b $c; } @mixin m 1 2 3;');
+            '@mixin m $a $b $c { v: $a $b $c; } @include m 1 2 3;');
         expect(result.css).to.eql('v: 1 2 3;');
         expect(result.warnings()).to.have.length(2);
     });


### PR DESCRIPTION
Rename @define-mixin, @mixin, and @mixin-content to @mixin, @include,
and @content, respectively, to better map to their related Sass
directives. This could help remove any confusion and possible errors
related to @mixin meaning opposite things in Sass and PostCSS, and will
make it much easier to transition projects.