### PR TITLE
Support global css mixins

### DIFF
--- a/test/mixins/d.css
+++ b/test/mixins/d.css
@@ -1,0 +1,3 @@
+@define-mixin d {
+  d: 4;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -99,15 +99,25 @@ describe('postcss-mixins', function () {
     });
 
     it('loads mixins from dir', function (done) {
-        test('a { @mixin a 1; @mixin b; }', 'a { a: 1; b: 2; }', done, {
-            mixinsDir: path.join(__dirname, 'mixins')
-        });
+        test(
+            'a { @mixin a 1; @mixin b; @mixin d; }',
+            'a { a: 1; b: 2; d: 4; }',
+            done,
+            {
+                mixinsDir: path.join(__dirname, 'mixins')
+            }
+        );
     });
 
     it('loads mixins from relative dir', function (done) {
-        test('a { @mixin a 1; @mixin b; }', 'a { a: 1; b: 2; }', done, {
-            mixinsDir: 'test/mixins/'
-        });
+        test(
+            'a { @mixin a 1; @mixin b; @mixin d; }',
+            'a { a: 1; b: 2; d: 4; }',
+            done,
+            {
+                mixinsDir: 'test/mixins/'
+            }
+        );
     });
 
     it('loads mixins from dirs', function (done) {
@@ -137,7 +147,7 @@ describe('postcss-mixins', function () {
     it('loads mixins from file globs', function (done) {
         test('a { @mixin a 1; @mixin c; }', 'a { a: 1; c: 3; }', done, {
             mixinsFiles: [
-                path.join(__dirname, 'mixins', '!(b.js)'),
+                path.join(__dirname, 'mixins', '*.!(json|css)'),
                 path.join(__dirname, 'other', '*')
             ]
         });


### PR DESCRIPTION
This PR allows you to stuff css files in your mixins dir, in which there can be any number of css mixins, defined via `@define-mixin`.