### PR TITLE
Fix mixins search on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var globby  = require('globby');
 var vars    = require('postcss-simple-vars');
 var path    = require('path');
 var fs      = require('fs');
+var isWindows = require('os').platform().indexOf('win32') !== -1;
 
 function insideDefine(rule) {
     var parent = rule.parent;
@@ -109,6 +110,7 @@ module.exports = postcss.plugin('postcss-mixins', function (opts) {
     var cwd    = process.cwd();
     var globs  = [];
     var mixins = { };
+    var noCaseSearch = !isWindows;
 
     if ( opts.mixinsDir ) {
         if ( !Array.isArray(opts.mixinsDir) ) {
@@ -134,7 +136,9 @@ module.exports = postcss.plugin('postcss-mixins', function (opts) {
             });
         };
 
-        return globby(globs, { nocase: true }).then(function (files) {
+        // Windows bug with {nocase: true} due to node-glob issue
+        // https://github.com/isaacs/node-glob/issues/123
+        return globby(globs, { nocase: noCaseSearch }).then(function (files) {
             return Promise.all(files.map(function (file) {
                 var ext      = path.extname(file);
                 var name     = path.basename(file, ext);


### PR DESCRIPTION
On Windows, the `mixinsDir` option, and the `mixinsFiles` option are broken (`mixinsDir` all the time, `mixinsFiles` when the glob contains a '\*') due to [this issue in node-glob](https://github.com/isaacs/node-glob/issues/123) (which is used by globby) : When the `{ nocase: true }` option is given to globby with a glob containing '\*', it becomes unable to find files.

No error is sent when that happens, and the result is that mixins can't be loaded, so when I try to use them I get "Undefined mixin" errors

This fix detects if the user is using Windows and switches the globby option `nocase` to `false` when he is.

Another option would be to expose the `nocase` value in postcss-mixins options, but as this problem isn't directly caused by postcss-mixins's code, I was reluctant to add an option for this. I can modify this PR to make that change though.