### PR TITLE
Start of configurable rules

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -215,3 +215,14 @@ test('works in sync mode on no option', t => {
     let output = 'a: 1';
     t.deepEqual(postcss(mixins()).process(input).css, output);
 });
+
+test('supports renaming mixin rules through options', t => {
+    let input = '@set a { color: blue; } @use a;';
+    let output = 'color: blue;';
+    t.deepEqual(postcss(mixins({
+        rules: {
+            mixin: 'use',
+            defineMixin: 'set'
+        }
+    })).process(input).css, output);
+});


### PR DESCRIPTION
This PR aims to allow the configuration of rule names when writing mixins. 

The primary use-case for this feature is for allowing this plugin to be used with other systems that have mixins already (sass). 

```javascript
postcss(mixins({
  rules: {
    mixin: 'use',
    defineMixin: 'set'
  }
}));
```

```css
@set black { color: black }
@use black;
```

It's not totally done yet... multiple unit tests started failing after I added my test in making me think the scope isn't being properly reset after each call. If anyone could point out my mistake here that'd be greatly appreciated. 

