### PR TITLE
support nested function mixins

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,9 @@ function insertMixin(result, mixins, rule, processMixins, opts) {
 
     } else if ( typeof mixin === 'function' ) {
         var args  = [rule].concat(params);
+        rule.walkAtRules(function (atRule) {
+          insertMixin(result, mixins, atRule, processMixins, opts)
+        });
         var nodes = mixin.apply(this, args);
         if ( typeof nodes === 'object' ) {
             insertObject(rule, nodes, processMixins);

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,25 @@ function run(t, input, output, opts) {
     });
 }
 
+test('supports nested function mixins', t => {
+  return run(t, 'a { color: black; @mixin parent { @mixin child; } }', 'a { color: black; .parent { color: white } }', {
+      mixins: {
+          parent: (mixin) => {
+            let rule = postcss.rule({ selector: `.parent` });
+            if (mixin.nodes) {
+              rule.append(mixin.nodes);
+            }
+            mixin.replaceWith(rule);
+          },
+          child: (mixin) => {
+            return {
+              color: 'white'
+            }
+          }
+      }
+  });
+});
+
 test('throws error on unknown mixin', t => {
     return postcss(mixins).process('@mixin A').catch(err => {
         t.deepEqual(err.reason, 'Undefined mixin A');


### PR DESCRIPTION
````css
@mixin parent {
  @mixin child; 
}
````

This works fine with `mixins` created in CSS.  But if the `mixins` are function mixins, the `@mixin child` rule is not evaluated.

This PR addresses this issue.
