### PR TITLE
Add parent path

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,9 +168,14 @@ module.exports = postcss.plugin('postcss-mixins', function (opts) {
                 var ext      = path.extname(file).toLowerCase();
                 var name     = path.basename(file, path.extname(file));
                 var relative = path.join(cwd, path.relative(cwd, file));
+                var parent = '';
+                if (opts.parent) {
+                    parent = opts.parent;
+                }
                 result.messages.push({
                     type: 'dependency',
-                    file: relative
+                    file: relative,
+                    parent: parent
                 });
                 return new Promise(function (resolve, reject) {
                     if ( ext === '.css' || ext === '.pcss' || ext === '.sss' ) {

--- a/test/test.test.js
+++ b/test/test.test.js
@@ -166,23 +166,68 @@ it('loads mixins from dir', () => {
         expect(result.messages).toEqual([
             {
                 file: path.join(__dirname, 'mixins/a.js'),
-                type: 'dependency'
+                type: 'dependency',
+                parent: ''
             },
             {
                 file: path.join(__dirname, 'mixins/b.json'),
-                type: 'dependency'
+                type: 'dependency',
+                parent: ''
             },
             {
                 file: path.join(__dirname, 'mixins/c.CSS'),
-                type: 'dependency'
+                type: 'dependency',
+                parent: ''
             },
             {
                 file: path.join(__dirname, 'mixins/d.sss'),
-                type: 'dependency'
+                type: 'dependency',
+                parent: ''
             },
             {
                 file: path.join(__dirname, 'mixins/e.pcss'),
-                type: 'dependency'
+                type: 'dependency',
+                parent: ''
+            }
+        ]);
+    });
+});
+
+it('loads mixins from dir with parent options', () => {
+    var parent =  path.join(__dirname, 'a.js');
+    return run(
+        'a { @mixin a 1; @mixin b; @mixin c; @mixin d; @mixin e; }',
+        'a { a: 1; b: 2; c: 3; d: 4; e: 5; }',
+        {
+            mixinsDir: path.join(__dirname, 'mixins'),
+            parent: path.join(__dirname, 'a.js')
+        }
+    ).then(result => {
+        expect(result.messages).toEqual([
+            {
+                file: path.join(__dirname, 'mixins/a.js'),
+                type: 'dependency',
+                parent: parent
+            },
+            {
+                file: path.join(__dirname, 'mixins/b.json'),
+                type: 'dependency',
+                parent: parent
+            },
+            {
+                file: path.join(__dirname, 'mixins/c.CSS'),
+                type: 'dependency',
+                parent: parent
+            },
+            {
+                file: path.join(__dirname, 'mixins/d.sss'),
+                type: 'dependency',
+                parent: parent
+            },
+            {
+                file: path.join(__dirname, 'mixins/e.pcss'),
+                type: 'dependency',
+                parent: parent
             }
         ]);
     });


### PR DESCRIPTION
Added `parent` path. ( default `process.cwd` like https://github.com/postcss/postcss-import/blob/master/index.js#L18 ) 

postcss-cli needs `parent` path because use `dependency-graph` when `--watch` options

- https://github.com/jriecken/dependency-graph/blob/ecac207c7712220f2a3d7a2f901f511ad83277a5/README.md#depgraph
- https://github.com/postcss/postcss-cli/blob/28fa45a8ed2e80198d6c1aca8d9be49717e702b9/lib/depGraph.js#L8-L9

