### PR TITLE
add mixinsText option

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,18 @@ require('postcss-mixins')({
 })
 ```
 
+### `mixinsText`
+
+Type: `string|string[]`
+
+All of your mixins as the actual contents of the files.
+
+```js
+require('postcss-mixins')({
+  mixinsText: '@define-mixin black { color: black; }'
+});
+```
+
 ### `silent`
 
 Remove unknown mixins and do not throw a error. Default is `false`.

--- a/index.js
+++ b/index.js
@@ -135,6 +135,12 @@ module.exports = postcss.plugin('postcss-mixins', function (opts) {
     })
   }
 
+  if (opts.mixinsText) {
+    if (!Array.isArray(opts.mixinsText)) {
+      opts.mixinsText = [opts.mixinsText]
+    }
+  }
+
   if (opts.mixinsFiles) globs = globs.concat(opts.mixinsFiles)
 
   return function (css, result) {
@@ -156,6 +162,15 @@ module.exports = postcss.plugin('postcss-mixins', function (opts) {
           mixins[i] = { mixin: opts.mixins[i] }
         }
       }
+
+      if (opts.mixinsText) {
+        opts.mixinsText.forEach(function (text) {
+          postcss.parse(text).walkAtRules('define-mixin', function (atrule) {
+            defineMixin(result, mixins, atrule)
+          })
+        })
+      }
+
       processMixins(css)
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -125,6 +125,14 @@ it('supports CSS mixins', function () {
   )
 })
 
+it('supports mixins text', function () {
+  return run(
+    'a { @mixin black; }',
+    'a { color: black; }',
+    { mixinsText: '@define-mixin black { color: black; }' }
+  )
+})
+
 it('uses variable', function () {
   return run(
     '@define-mixin color $color { color: $color $other; } ' +


### PR DESCRIPTION
I need the ability to run this plugin synchronously. This PR add an option to pass all your mixins as the actually CSS text. This enable you to load whatever you want synchronously so postcss can stay sync

closes #95 