### PR TITLE
Bug: Mixins object throws

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ module.exports = postcss.plugin('postcss-mixins', function (opts) {
     function process () {
       if (typeof opts.mixins === 'object') {
         for (var i in opts.mixins) {
-          mixins[i] = { mixin: opts.mixins[i] }
+          mixins[i] = { mixin: opts.mixins[i], args: [] }
         }
       }
       processMixins(css)


### PR DESCRIPTION
If you supply parsed mixins in an object I get the following error

```
(node:4723) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'length' of undefined
    at /Users/alisowski/Documents/cgds/components/Card/src/Card.css:2:3
    at insertMixin (/Users/alisowski/Documents/cgds/node_modules/postcss-mixins/index.js:66:31)
```

These mixins never get `args` set 

https://github.com/postcss/postcss-mixins/blob/master/index.js#L156

so we to this line 

https://github.com/postcss/postcss-mixins/blob/master/index.js#L62

and an error occurs
