### PR TITLE
Require parse from postcss-js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 let { join, basename, extname, relative } = require('path')
 let { promisify } = require('util')
 let { platform } = require('os')
-let jsToCss = require('postcss-js/parser')
+let { parse } = require('postcss-js')
 let sugarss = require('sugarss')
 let globby = require('globby')
 let vars = require('postcss-simple-vars')
@@ -85,7 +85,7 @@ function processMixinContent (rule, from) {
 }
 
 function insertObject (rule, obj) {
-  let root = jsToCss(obj)
+  let root = parse(obj)
   root.each(node => {
     node.source = rule.source
   })


### PR DESCRIPTION
Resolves issues of 
```
[!] Error: Could not load /PackagePath/node_modules/postcss-js/parser (imported by node_modules/postcss-mixins/index.js): ENOENT: no such file or directory, open '/PackagePath/node_modules/postcss-js/parser'`
```