### PR TITLE
Fix pattern for globby

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ module.exports = (opts = {}) => {
     if (!Array.isArray(opts.mixinsDir)) {
       opts.mixinsDir = [opts.mixinsDir]
     }
-    loadFrom = opts.mixinsDir.map(dir => join(dir, '*.{js,json,css,sss,pcss}'))
+    loadFrom = opts.mixinsDir.map(dir => join(dir, '*.{js,json,css,sss,pcss}').replace(/\\/g, '/'))
   }
   if (opts.mixinsFiles) loadFrom = loadFrom.concat(opts.mixinsFiles)
 


### PR DESCRIPTION
The path join returns with back-slashes when it is run on Windows and is breaking globby which requires forward-slashes