### PR TITLE
feat: changed the logic of registering dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,6 @@ async function loadGlobalMixin(helpers, globs) {
   let mixins = {}
   await Promise.all(
     files.map(async i => {
-      // console.log(i)
       let ext = extname(i).toLowerCase()
       let name = basename(i, extname(i))
       let path = join(cwd, relative(cwd, i))
@@ -65,18 +64,10 @@ async function loadGlobalMixin(helpers, globs) {
 }
 
 function addGlobalMixins(helpers, local, global, parent) {
-  let paths = Object.keys(global).reduce(
-    (acc, mixinName) => [...acc, global[mixinName].file],
-    []
-  )
-  let dirs = Object.keys(
-    paths.reduce((acc, mixinPath) => {
-      acc[dirname(relative(process.cwd(), mixinPath))] = true
-      return acc
-    }, {})
-  )
+  let dirsOfMixins = Object.values(global).map(({ file }) => dirname(file))
+  let uniqueDirsOfMixins = Array.from(new Set(dirsOfMixins))
 
-  dirs.forEach(dirOfMixin => {
+  uniqueDirsOfMixins.forEach(dirOfMixin => {
     helpers.result.messages.push({
       type: 'dir-dependency',
       dir: dirOfMixin,

--- a/index.js
+++ b/index.js
@@ -75,14 +75,14 @@ function addGlobalMixins(helpers, local, global, parent) {
   }
 }
 
-function watchNewMixins(helpers, mixinsDirs, parent, glob) {
+function watchNewMixins(helpers, mixinsDirs, glob) {
   let uniqueDirsPath = Array.from(new Set(mixinsDirs))
   for (let dir of uniqueDirsPath) {
     helpers.result.messages.push({
       type: 'dir-dependency',
       dir,
       glob,
-      parent: parent || ''
+      parent: ''
     })
   }
 }
@@ -215,7 +215,7 @@ module.exports = (opts = {}) => {
         },
         OnceExit(_, helpers) {
           if (opts.mixinsDir && opts.mixinsDir.length > 0) {
-            watchNewMixins(helpers, opts.mixinsDir, opts.parent, MIXINS_GLOB)
+            watchNewMixins(helpers, opts.mixinsDir, MIXINS_GLOB)
           }
         }
       }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -212,7 +212,7 @@ it('loads mixins from dir', async () => {
     })
   ).toEqual([
     {
-      dir: 'test/mixins',
+      dir: join(__dirname, 'mixins'),
       type: 'dir-dependency',
       parent: ''
     }
@@ -235,7 +235,7 @@ it('loads mixins from dir with parent options', async () => {
     })
   ).toEqual([
     {
-      dir: 'test/mixins',
+      dir: join(__dirname, 'mixins'),
       type: 'dir-dependency',
       parent
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -212,28 +212,8 @@ it('loads mixins from dir', async () => {
     })
   ).toEqual([
     {
-      file: join(__dirname, 'mixins/a.js'),
-      type: 'dependency',
-      parent: ''
-    },
-    {
-      file: join(__dirname, 'mixins/b.json'),
-      type: 'dependency',
-      parent: ''
-    },
-    {
-      file: join(__dirname, 'mixins/c.CSS'),
-      type: 'dependency',
-      parent: ''
-    },
-    {
-      file: join(__dirname, 'mixins/d.sss'),
-      type: 'dependency',
-      parent: ''
-    },
-    {
-      file: join(__dirname, 'mixins/e.pcss'),
-      type: 'dependency',
+      dir: 'test/mixins',
+      type: 'dir-dependency',
       parent: ''
     }
   ])
@@ -255,28 +235,8 @@ it('loads mixins from dir with parent options', async () => {
     })
   ).toEqual([
     {
-      file: join(__dirname, 'mixins/a.js'),
-      type: 'dependency',
-      parent
-    },
-    {
-      file: join(__dirname, 'mixins/b.json'),
-      type: 'dependency',
-      parent
-    },
-    {
-      file: join(__dirname, 'mixins/c.CSS'),
-      type: 'dependency',
-      parent
-    },
-    {
-      file: join(__dirname, 'mixins/d.sss'),
-      type: 'dependency',
-      parent
-    },
-    {
-      file: join(__dirname, 'mixins/e.pcss'),
-      type: 'dependency',
+      dir: 'test/mixins',
+      type: 'dir-dependency',
       parent
     }
   ])

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -212,9 +212,35 @@ it('loads mixins from dir', async () => {
     })
   ).toEqual([
     {
-      dir: join(__dirname, 'mixins'),
-      type: 'dir-dependency',
+      file: join(__dirname, 'mixins/a.js'),
+      type: 'dependency',
       parent: ''
+    },
+    {
+      file: join(__dirname, 'mixins/b.json'),
+      type: 'dependency',
+      parent: ''
+    },
+    {
+      file: join(__dirname, 'mixins/c.CSS'),
+      type: 'dependency',
+      parent: ''
+    },
+    {
+      file: join(__dirname, 'mixins/d.sss'),
+      type: 'dependency',
+      parent: ''
+    },
+    {
+      file: join(__dirname, 'mixins/e.pcss'),
+      type: 'dependency',
+      parent: ''
+    },
+    {
+      dir: join(__dirname, 'mixins'),
+      glob: '*.{js,json,css,sss,pcss}',
+      parent: '',
+      type: 'dir-dependency'
     }
   ])
 })
@@ -235,9 +261,35 @@ it('loads mixins from dir with parent options', async () => {
     })
   ).toEqual([
     {
-      dir: join(__dirname, 'mixins'),
-      type: 'dir-dependency',
+      file: join(__dirname, 'mixins/a.js'),
+      type: 'dependency',
       parent
+    },
+    {
+      file: join(__dirname, 'mixins/b.json'),
+      type: 'dependency',
+      parent
+    },
+    {
+      file: join(__dirname, 'mixins/c.CSS'),
+      type: 'dependency',
+      parent
+    },
+    {
+      file: join(__dirname, 'mixins/d.sss'),
+      type: 'dependency',
+      parent
+    },
+    {
+      file: join(__dirname, 'mixins/e.pcss'),
+      type: 'dependency',
+      parent
+    },
+    {
+      dir: join(__dirname, 'mixins'),
+      glob: '*.{js,json,css,sss,pcss}',
+      parent,
+      type: 'dir-dependency'
     }
   ])
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -208,7 +208,7 @@ it('loads mixins from dir', async () => {
   )
   expect(
     result.messages.sort((a, b) => {
-      return a.file.localeCompare(b.file)
+      return a.file?.localeCompare(b.file)
     })
   ).toEqual([
     {
@@ -257,7 +257,7 @@ it('loads mixins from dir with parent options', async () => {
   )
   expect(
     result.messages.sort((a, b) => {
-      return a.file.localeCompare(b.file)
+      return a.file?.localeCompare(b.file)
     })
   ).toEqual([
     {
@@ -288,7 +288,7 @@ it('loads mixins from dir with parent options', async () => {
     {
       dir: join(__dirname, 'mixins'),
       glob: '*.{js,json,css,sss,pcss}',
-      parent,
+      parent: '',
       type: 'dir-dependency'
     }
   ])


### PR DESCRIPTION
Hi!
I've changed the logic of registering dependencies:
I am detecting folders where mixins hosted and then connecting each unique folder