### PR TITLE
Fix at-rules being processed as mixins inside of @mixin-content in function mixins

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,9 @@ function insertMixin(helpers, mixins, rule, opts) {
   } else if (typeof mixin === 'function') {
     let args = [rule].concat(params)
     rule.walkAtRules(atRule => {
-      insertMixin(helpers, mixins, atRule, opts)
+      if (['add-mixin', 'mixin'].includes(atRule.name)) {
+        insertMixin(helpers, mixins, atRule, opts)
+      }
     })
     let nodes = mixin(...args)
     if (typeof nodes === 'object') {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -36,6 +36,17 @@ test('throws error on brackets in mixin', async () => {
   )
 })
 
+test('does not throw error on brackets in at-rules inside function mixins', async () => {
+  await run(
+    '@mixin a { @supports (max(0px)) { color: black; } }',
+    '.a { @supports (max(0px)) { color: black; } }',
+    {
+      mixins: {
+        a() { return { '.a': { '@mixin-content' : {} } } }
+      }
+    })
+})
+
 test('cans remove unknown mixin on request', async () => {
   await run('@mixin A; a{}', 'a{}', { silent: true })
 })


### PR DESCRIPTION
Consider the following css:
```scss
@mixin foo {
  @supports (padding: max(0px)) {
    color: red;
  }
}
```

And the following function mixin:
```scss
function foo() {
  return { '.foo': { '@mixin-content' : {} } }
}
```

It breaks with the following error:
```
... Remove brackets from mixin. Like: @mixin name(1px) → @mixin name 1px
  4 |
  5 |     @mixin foo {
> 6 |       @supports (padding: max(0px)) {
    |       ^
  7 |         color: red;
  8 |       }
```

I think this happens due to this part of code:
* https://github.com/postcss/postcss-mixins/blob/main/index.js#L153-L155 (if it's function mixin then insert mixins in _all_ atrules)

The proposed PR attempts to fix this by running `insertMixin` only on `@mixin` and `@add-mixin` rules.