### PR TITLE
Enable hot reloading of the functional mixins

### DIFF
--- a/test/deps/f.js
+++ b/test/deps/f.js
@@ -1,0 +1,1 @@
+module.exports = require('./g')

--- a/test/deps/g.js
+++ b/test/deps/g.js
@@ -1,0 +1,3 @@
+module.exports = {
+  g: '5'
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -341,6 +341,31 @@ test('loads mixins from file globs', async () => {
   })
 })
 
+test('loads mixins with dependencies', async () => {
+  let result = await run(
+    'a { @mixin f; }',
+    'a { g: 5; }',
+    {
+      mixinsFiles: join(__dirname, 'deps', 'f.js')
+    }
+  )
+  equal(
+    result.messages.sort((a, b) => a.file && a.file.localeCompare(b.file)),
+    [
+      {
+        file: join(__dirname, 'deps/f.js'),
+        type: 'dependency',
+        parent: ''
+      },
+      {
+        file: join(__dirname, 'deps/g.js'),
+        type: 'dependency',
+        parent: join(__dirname, 'deps/f.js')
+      }
+    ]
+  )
+})
+
 test('coverts mixins values', async () => {
   let processor = postcss(
     mixins({


### PR DESCRIPTION
Hello,

In additional to the #145 I added `try ... catch` around `require` of mixin file. In case there is a syntax of any other error in a single mixin file, other mixins will be loaded successfully. Should I write tests for this case?