### PR TITLE
Add .cjs file extension support

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ let sugarss = require('sugarss')
 let vars = require('postcss-simple-vars')
 let glob = require('fast-glob')
 
-let MIXINS_GLOB = '*.{js,json,css,sss,pcss}'
+let MIXINS_GLOB = '*.{js,cjs,json,css,sss,pcss}'
 let IS_WIN = platform().includes('win32')
 
 function addMixin(helpers, mixins, rule, file) {


### PR DESCRIPTION
Vite requires PostCSS config to be loaded as CommonJS using the `.cjs` file extension. Currently files with a `.cjs` extension are ignored by the `mixinsFiles` and `mixinsDir` options. This fixes that.