### PR TITLE
Replace `fast-glob` with a lighter `tinyglobby`

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ module.exports = {
 Type: `string|string[]`
 
 Similar to [`mixinsDir`](#mixinsdir); except, you can provide
-[fast-glob](https://github.com/mrmlnc/fast-glob) syntax to target or not target
+[tinyglobby](https://github.com/SuperchupuDev/tinyglobby) syntax to target or not target
 specific files.
 
 ```js

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 let { readFileSync } = require('node:fs')
-let { platform } = require('node:os')
 let { basename, extname, join, relative } = require('node:path')
 let { parse } = require('postcss-js')
 let vars = require('postcss-simple-vars')
@@ -7,7 +6,6 @@ let sugarss = require('sugarss')
 let { globSync } = require('tinyglobby')
 
 let MIXINS_GLOB = '*.{js,cjs,mjs,json,css,sss,pcss}'
-let IS_WIN = platform().includes('win32')
 
 function addMixin(helpers, mixins, rule, file) {
   let name = rule.params.split(/\s/, 1)[0]
@@ -48,7 +46,7 @@ function processModulesForHotReloadRecursively(module, helpers) {
 
 function loadGlobalMixin(helpers, globs) {
   let cwd = process.cwd()
-  let files = globSync(globs, { caseSensitiveMatch: !IS_WIN })
+  let files = globSync(globs, { caseSensitiveMatch: false })
   let mixins = {}
   files.forEach(i => {
     let ext = extname(i).toLowerCase()

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 let { readFileSync } = require('node:fs')
+let { platform } = require('node:os')
 let { basename, extname, join, relative } = require('node:path')
 let { parse } = require('postcss-js')
 let vars = require('postcss-simple-vars')
@@ -6,6 +7,7 @@ let sugarss = require('sugarss')
 let { globSync } = require('tinyglobby')
 
 let MIXINS_GLOB = '*.{js,cjs,mjs,json,css,sss,pcss}'
+let IS_WIN = platform().includes('win32')
 
 function addMixin(helpers, mixins, rule, file) {
   let name = rule.params.split(/\s/, 1)[0]
@@ -46,7 +48,7 @@ function processModulesForHotReloadRecursively(module, helpers) {
 
 function loadGlobalMixin(helpers, globs) {
   let cwd = process.cwd()
-  let files = globSync(globs)
+  let files = globSync(globs, { caseSensitiveMatch: !IS_WIN })
   let mixins = {}
   files.forEach(i => {
     let ext = extname(i).toLowerCase()

--- a/index.js
+++ b/index.js
@@ -1,13 +1,11 @@
 let { basename, extname, join, relative } = require('node:path')
 let { readFileSync } = require('node:fs')
-let { platform } = require('node:os')
 let { parse } = require('postcss-js')
 let sugarss = require('sugarss')
 let vars = require('postcss-simple-vars')
-let glob = require('fast-glob')
+let { globSync } = require('tinyglobby')
 
 let MIXINS_GLOB = '*.{js,cjs,mjs,json,css,sss,pcss}'
-let IS_WIN = platform().includes('win32')
 
 function addMixin(helpers, mixins, rule, file) {
   let name = rule.params.split(/\s/, 1)[0]
@@ -48,7 +46,7 @@ function processModulesForHotReloadRecursively(module, helpers) {
 
 function loadGlobalMixin(helpers, globs) {
   let cwd = process.cwd()
-  let files = glob.sync(globs, { caseSensitiveMatch: IS_WIN })
+  let files = globSync(globs)
   let mixins = {}
   files.forEach(i => {
     let ext = extname(i).toLowerCase()

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-let { globSync } = require('tinyglobby')
 let { readFileSync } = require('node:fs')
 let { basename, extname, join, relative } = require('node:path')
 let { parse } = require('postcss-js')
 let vars = require('postcss-simple-vars')
 let sugarss = require('sugarss')
+let { globSync } = require('tinyglobby')
 
 let MIXINS_GLOB = '*.{js,cjs,mjs,json,css,sss,pcss}'
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "postcss-js": "^4.0.1",
     "postcss-simple-vars": "^7.0.1",
     "sugarss": "^4.0.1",
-    "tinyglobby": "^0.2.5"
+    "tinyglobby": "^0.2.6"
   },
   "devDependencies": {
     "@logux/eslint-config": "^53.4.0",
@@ -65,5 +65,6 @@
   },
   "clean-publish": {
     "cleanDocs": true
-  }
+  },
+  "packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1"
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,5 @@
   },
   "clean-publish": {
     "cleanDocs": true
-  },
-  "packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "postcss": "^8.2.14"
   },
   "dependencies": {
-    "fast-glob": "^3.3.2",
     "postcss-js": "^4.0.1",
     "postcss-simple-vars": "^7.0.1",
-    "sugarss": "^4.0.1"
+    "sugarss": "^4.0.1",
+    "tinyglobby": "^0.2.5"
   },
   "devDependencies": {
     "@logux/eslint-config": "^53.0.1",
@@ -65,5 +65,6 @@
   },
   "clean-publish": {
     "cleanDocs": true
-  }
+  },
+  "packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1(postcss@8.4.45)
       tinyglobby:
-        specifier: ^0.2.5
-        version: 0.2.5
+        specifier: ^0.2.6
+        version: 0.2.6
     devDependencies:
       '@logux/eslint-config':
         specifier: ^53.4.0
@@ -1107,8 +1107,8 @@ packages:
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
-  tinyglobby@0.2.5:
-    resolution: {integrity: sha512-Dlqgt6h0QkoHttG53/WGADNh9QhcjCAIZMTERAVhdpmIBEejSuLI9ZmGKWzB7tweBjlk30+s/ofi4SLmBeTYhw==}
+  tinyglobby@0.2.6:
+    resolution: {integrity: sha512-NbBoFBpqfcgd1tCiO8Lkfdk+xrA7mlLR9zgvZcZWQQwU63XAfUePyd6wZBaU93Hqw347lHnwFzttAkemHzzz4g==}
     engines: {node: '>=12.0.0'}
 
   to-regex-range@5.0.1:
@@ -2388,7 +2388,7 @@ snapshots:
 
   text-table@0.2.0: {}
 
-  tinyglobby@0.2.5:
+  tinyglobby@0.2.6:
     dependencies:
       fdir: 6.3.0(picomatch@4.0.2)
       picomatch: 4.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.2
       postcss-js:
         specifier: ^4.0.1
         version: 4.0.1(postcss@8.4.38)
@@ -20,6 +17,9 @@ importers:
       sugarss:
         specifier: ^4.0.1
         version: 4.0.1(postcss@8.4.38)
+      tinyglobby:
+        specifier: ^0.2.5
+        version: 0.2.5
     devDependencies:
       '@logux/eslint-config':
         specifier: ^53.0.1
@@ -574,6 +574,14 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
+  fdir@6.3.0:
+    resolution: {integrity: sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -960,6 +968,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
@@ -1125,6 +1137,10 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  tinyglobby@0.2.5:
+    resolution: {integrity: sha512-Dlqgt6h0QkoHttG53/WGADNh9QhcjCAIZMTERAVhdpmIBEejSuLI9ZmGKWzB7tweBjlk30+s/ofi4SLmBeTYhw==}
+    engines: {node: '>=12.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1938,6 +1954,10 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fdir@6.3.0(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -2316,6 +2336,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   possible-typed-array-names@1.0.0: {}
 
   postcss-js@4.0.1(postcss@8.4.38):
@@ -2476,6 +2498,11 @@ snapshots:
       minimatch: 3.1.2
 
   text-table@0.2.0: {}
+
+  tinyglobby@0.2.5:
+    dependencies:
+      fdir: 6.3.0(picomatch@4.0.2)
+      picomatch: 4.0.2
 
   to-regex-range@5.0.1:
     dependencies:


### PR DESCRIPTION
This PR is a suggestion to switch from `fast-glob` (17 subdependencies) to a lighter [`tinyglobby`](https://www.npmjs.com/package/tinyglobby) which aims to behave the same way with a much smaller footprint (at present it only depends on `fdir` and `picomatch`).

Please check #6ee4084's commit message for rationale regarding removing the distinction between Windows and Unix systems regarding case sensitivity when matching.