### PR TITLE
Add `expandDirectories: false` for better compatibility with `fast-glob`

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,10 @@ function processModulesForHotReloadRecursively(module, helpers) {
 
 function loadGlobalMixin(helpers, globs) {
   let cwd = process.cwd()
-  let files = globSync(globs, { caseSensitiveMatch: false })
+  let files = globSync(globs, {
+    caseSensitiveMatch: false,
+    expandDirectories: false
+  })
   let mixins = {}
   files.forEach(i => {
     let ext = extname(i).toLowerCase()


### PR DESCRIPTION
After my PR was merged yesterday (https://github.com/postcss/postcss-mixins/pull/165), I spoke to the creator of `tinyglobby` and they suggested setting this option for better compatibility with `fast-glob`. It's also mentioned in the project's README.