### PR TITLE
Ignore `node_modules` and `.git` when globbing

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,8 @@ function loadGlobalMixin(helpers, globs) {
   let cwd = process.cwd()
   let files = globSync(globs, {
     caseSensitiveMatch: false,
-    expandDirectories: false
+    expandDirectories: false,
+    ignore: ['**/node_modules/**', '**/.git/**']
   })
   let mixins = {}
   files.forEach(i => {


### PR DESCRIPTION
speeds up globbing by ignoring `node_modules` and `.git`, probably fixes #167

ran the tests to see if the `globSync` function gets called multiple times per test but it seems to only get called once per test, unlike what's described in the linked issue