### PR TITLE
Do not ignore `node_modules` when globbing

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,8 @@ function loadGlobalMixin(helpers, globs) {
   let cwd = process.cwd()
   let files = globSync(globs, {
     caseSensitiveMatch: false,
-    expandDirectories: false
+    expandDirectories: false,
+    ignore: ['**/.git/**']
   })
   let mixins = {}
   files.forEach(i => {

--- a/index.js
+++ b/index.js
@@ -48,8 +48,7 @@ function loadGlobalMixin(helpers, globs) {
   let cwd = process.cwd()
   let files = globSync(globs, {
     caseSensitiveMatch: false,
-    expandDirectories: false,
-    ignore: ['**/node_modules/**', '**/.git/**']
+    expandDirectories: false
   })
   let mixins = {}
   files.forEach(i => {


### PR DESCRIPTION
It was reported in https://github.com/postcss/postcss-mixins/issues/167#issuecomment-2378599812 that matching from `node_modules` is in fact needed, so this PR reverts that aspect in particular